### PR TITLE
check for too long LEB128 sequences with tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@
 /zrld.dSYM/
 /zrle
 /zrle.dSYM/
+/leb128d
+/leb128d.dSYM/
+/leb128e
+/leb128e.dSYM/

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,7 @@
 CFLAGS ?= -std=c99 -O3
+# assume UNIX by default:
+CPP_DEFINES ?= -DIO_UNLOCKED
+# set to -DIO_NOLOCK to avoid locking on Windows
 
 all: zrle zrld
 

--- a/Makefile
+++ b/Makefile
@@ -3,15 +3,17 @@ CFLAGS ?= -std=c99 -O3
 CPP_DEFINES ?= -DIO_UNLOCKED
 # set to -DIO_NOLOCK to avoid locking on Windows
 
-all: zrle zrld
+OUTPUTS = zrle zrld leb128e leb128d
 
-zrle zrld: zrl.c
+all: $(OUTPUTS)
+
+$(OUTPUTS): zrl.c
 	cc $(CFLAGS) -DZRLF=$@ $< -o $@ $(CPP_DEFINES)
 
-test: zrle zrld
+test: $(OUTPUTS)
 	./test.sh
 
 clean:
-	rm -f zrle zrld
+	rm -f $(OUTPUTS)
 
 .PHONY: all test clean

--- a/test.sh
+++ b/test.sh
@@ -1,17 +1,17 @@
 #!/usr/bin/env bash
 
 for i in {1..11}; do
-	cmp <(./zrle data/$i.raw) data/$i.zrl
+    cmp <(./zrle data/$i.raw) data/$i.zrl
 done
 
 for i in {1..11}; do
-	cmp <(./zrld data/$i.zrl) data/$i.raw
+    cmp <(./zrld data/$i.zrl) data/$i.raw
 done
 
 cmp <(head -c1000 /dev/zero | ./zrle) <(printf '\0\xe7\x07')
 cmp <(printf '\0\xe7\x07' | ./zrld) <(head -c1000 /dev/zero)
 
 for n in {0..512}; do
-	cmp <(head -c$n /dev/zero; yes | head -c$n) \
+    cmp <(head -c$n /dev/zero; yes | head -c$n) \
        <((head -c$n /dev/zero; yes | head -c$n) | ./zrle | ./zrld)
 done

--- a/test.sh
+++ b/test.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+# zrl encoding & decoding
+
 for i in {1..11}; do
     cmp <(./zrle data/$i.raw) data/$i.zrl
 done
@@ -18,3 +20,66 @@ done
 
 cmp <(./zrle /dev/null) /dev/null
 cmp <(./zrld /dev/null) /dev/null
+
+# leb128 encoding & decoding
+
+for n in {0..127}; do
+    x=$(printf "%x" $n)
+    cmp <(printf "\\x$x" | ./leb128e) <(printf "\\x$x")
+    cmp <(printf "\\x$x\0\0\0\0\0\0\0" | ./leb128e) <(printf "\\x$x")
+    cmp <(printf "\\x$x" | ./leb128d) <(printf "\\x$x\0\0\0\0\0\0\0")
+done
+
+cmp <(printf '\0' | ./leb128d) <(printf '\0\0\0\0\0\0\0\0')
+cmp <(printf '\x80\0' | ./leb128d) <(printf '\0\0\0\0\0\0\0\0')
+cmp <(printf '\x80\x80\x80\x80\x80\x80\x80\x80\x80\0' | ./leb128d) \
+    <(printf '\0\0\0\0\0\0\0\0')
+
+cmp <(printf '\xff\xff\xff\xff\xff\xff\xff\x7f' | ./leb128e) \
+    <(printf '\xff\xff\xff\xff\xff\xff\xff\xff\x7f')
+cmp <(printf '\xff\xff\xff\xff\xff\xff\xff\xff\x7f' | ./leb128d) \
+    <(printf '\xff\xff\xff\xff\xff\xff\xff\x7f')
+
+cmp <(printf '\xff\xff\xff\xff\xff\xff\xff\xff' | ./leb128e) \
+    <(printf '\xff\xff\xff\xff\xff\xff\xff\xff\xff\x01')
+cmp <(printf '\xff\xff\xff\xff\xff\xff\xff\xff\xff\x01' | ./leb128d) \
+    <(printf '\xff\xff\xff\xff\xff\xff\xff\xff')
+
+cmp <(printf '\0\0\0\0\0\0\0\x80' | ./leb128e) \
+    <(printf '\x80\x80\x80\x80\x80\x80\x80\x80\x80\x01')
+cmp <(printf '\x80\x80\x80\x80\x80\x80\x80\x80\x80\x01' | ./leb128d) \
+    <(printf '\0\0\0\0\0\0\0\x80')
+
+cmp <(printf '\x09\xc4\xc1\x50\x20\x0c\x04\x01' | ./leb128e) \
+    <(printf '\x89\x88\x87\x86\x85\x84\x83\x82\x01')
+cmp <(printf '\x89\x88\x87\x86\x85\x84\x83\x82\x01' | ./leb128d) \
+    <(printf '\x09\xc4\xc1\x50\x20\x0c\x04\x01')
+
+# error checking
+
+err=$(! printf '\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff' | ./leb128d 2>&1)
+test err == "Too large LEB128 value in file '<stdin>'"
+
+err=$(! printf '\x80\x80\x80\x80\x80\x80\x80\x80\x80\x02' | ./leb128d 2>&1)
+test err == "Too large LEB128 value in file '<stdin>'"
+
+err=$(! printf '\x80\x80\x80\x80\x80\x80\x80\x80\x80\x80' | ./leb128d 2>&1)
+test err == "Too large LEB128 value in file '<stdin>'"
+
+cmp <(printf '\0\xff\xff\xff\xff\xff\xff\xff\xff\xff\x01' | ./zrld | head -c1000) \
+    <(head -c1000 /dev/zero)
+
+err=$(! printf '\0\xff\xff\xff\xff\xff\xff\xff\xff\xff\x02' | ./zrld 2>&1)
+test err == "Too large LEB128 value in file '<stdin>'"
+
+err=$(! printf '\xff' | ./leb128d 2>&1)
+test "$err" == "Premature end of file '<stdin>'"
+
+err=$(! printf '\x80' | ./leb128d 2>&1)
+test "$err" == "Premature end of file '<stdin>'"
+
+err=$(! printf '\0\xff' | ./zrld 2>&1)
+test "$err" == "Premature end of file '<stdin>'"
+
+err=$(! printf '\0\x80' | ./zrld 2>&1)
+test "$err" == "Premature end of file '<stdin>'"

--- a/test.sh
+++ b/test.sh
@@ -15,3 +15,6 @@ for n in {0..512}; do
     cmp <(head -c$n /dev/zero; yes | head -c$n) \
        <((head -c$n /dev/zero; yes | head -c$n) | ./zrle | ./zrld)
 done
+
+cmp <(./zrle /dev/null) /dev/null
+cmp <(./zrld /dev/null) /dev/null

--- a/zrl.c
+++ b/zrl.c
@@ -14,7 +14,7 @@
 #define fputc _putc_nolock
 #endif
 
-int read_byte(const char *path, FILE *file) {
+static int read_byte(const char *path, FILE *file) {
     int c = fgetc(file);
     if (c == EOF) {
         int err = ferror(file);
@@ -26,7 +26,7 @@ int read_byte(const char *path, FILE *file) {
     return c;
 }
 
-void write_byte(int c) {
+static void write_byte(int c) {
     if (c == EOF) {
         fprintf(stderr, "Internal error: write_byte(EOF) called\n");
         exit(1);
@@ -39,7 +39,7 @@ void write_byte(int c) {
     }
 }
 
-uint64_t read_leb128(const char *path, FILE *file) {
+static uint64_t read_leb128(const char *path, FILE *file) {
     uint64_t n = 0;
     for (int shift = 0;; shift += 7) {
         int c = read_byte(path, file);
@@ -52,7 +52,7 @@ uint64_t read_leb128(const char *path, FILE *file) {
     }
 }
 
-void write_leb128(uint64_t n) {
+static void write_leb128(uint64_t n) {
     while (1) {
         uint8_t c = n & 0x7f;
         uint8_t more = (n >>= 7) != 0;
@@ -62,7 +62,7 @@ void write_leb128(uint64_t n) {
     }
 }
 
-void encode(const char *path, FILE *file) {
+static void encode(const char *path, FILE *file) {
     while (1) {
         int c = read_byte(path, file);
     top:
@@ -80,7 +80,7 @@ void encode(const char *path, FILE *file) {
     }
 }
 
-void decode(const char *path, FILE *file) {
+static void decode(const char *path, FILE *file) {
     while (1) {
         int c = read_byte(path, file);
         if (c == EOF) return;
@@ -95,7 +95,7 @@ void decode(const char *path, FILE *file) {
 #define zrle 'E'
 #define zrld 'D'
 
-void zrlf(const char *path, FILE *file) {
+static void zrlf(const char *path, FILE *file) {
 #if ZRLF == zrle
     encode(path, file);
 #elif ZRLF == zrld

--- a/zrl.c
+++ b/zrl.c
@@ -28,7 +28,7 @@ int read_byte(const char *path, FILE *file) {
 
 void write_byte(int c) {
     if (c == EOF) {
-        fprintf(stderr, "Programmer error: write_byte(EOF) called\n");
+        fprintf(stderr, "Internal error: write_byte(EOF) called\n");
         exit(1);
     }
     int r = fputc(c, stdout);

--- a/zrl.c
+++ b/zrl.c
@@ -14,6 +14,12 @@
 #define fputc _putc_nolock
 #endif
 
+static int fpeek(FILE *file) {
+    int c = fgetc(file);
+    ungetc(c, file);
+    return c;
+}
+
 static int read_byte(const char *path, FILE *file) {
     int c = fgetc(file);
     if (c == EOF) {
@@ -41,28 +47,34 @@ static void write_byte(int c) {
 
 static uint64_t read_leb128(const char *path, FILE *file) {
     uint64_t n = 0;
-    for (int shift = 0;; shift += 7) {
-        int c = read_byte(path, file);
+    for (int shift = 0; shift < 64; shift += 7) {
+        uint64_t c = read_byte(path, file);
         if (c == EOF) {
             fprintf(stderr, "Premature end of file '%s'", path);
             exit(1);
         }
-        n |= (c & 0x7f) << shift;
-        if (!(c & 0x80)) return n;
+        int more = (c & 0x80) != 0;
+        c &= 0x7f;
+        if (c << shift >> shift != c) break;
+        n |= c << shift;
+        if (!more) return n;
     }
+    fprintf(stderr, "Too large LEB128 value in file '%s'", path);
+    exit(1);
 }
 
 static void write_leb128(uint64_t n) {
     while (1) {
-        uint8_t c = n & 0x7f;
-        uint8_t more = (n >>= 7) != 0;
-        c |= more << 7;
-        write_byte(c);
+        uint8_t b = 0x7f & n;
+        n >>= 7;
+        uint8_t more = n != 0;
+        b |= more << 7;
+        write_byte(b);
         if (!more) return;
     }
 }
 
-static void encode(const char *path, FILE *file) {
+static void zrl_encode(const char *path, FILE *file) {
     while (1) {
         int c = read_byte(path, file);
     top:
@@ -80,7 +92,7 @@ static void encode(const char *path, FILE *file) {
     }
 }
 
-static void decode(const char *path, FILE *file) {
+static void zrl_decode(const char *path, FILE *file) {
     while (1) {
         int c = read_byte(path, file);
         if (c == EOF) return;
@@ -92,14 +104,42 @@ static void decode(const char *path, FILE *file) {
     }
 }
 
-#define zrle 'E'
-#define zrld 'D'
+static void leb128_encode(const char *path, FILE *file) {
+    while (fpeek(file) != EOF) {
+        uint64_t n = 0;
+        for (int shift = 0; shift < 64; shift += 8) {
+            uint64_t c = read_byte(path, file);
+            if (c == EOF) break;
+            n |= c << shift;
+        }
+        write_leb128(n);
+    }
+}
+
+static void leb128_decode(const char *path, FILE *file) {
+    while (fpeek(file) != EOF) {
+        uint64_t n = read_leb128(path, file);
+        for (int i = 0; i < 8; i++) {
+            write_byte(n & 0xff);
+            n >>= 8;
+        }
+    }
+}
+
+#define zrle 1
+#define zrld 2
+#define leb128e 3
+#define leb128d 4
 
 static void zrlf(const char *path, FILE *file) {
 #if ZRLF == zrle
-    encode(path, file);
+    zrl_encode(path, file);
 #elif ZRLF == zrld
-    decode(path, file);
+    zrl_decode(path, file);
+#elif ZRLF == leb128e
+    leb128_encode(path, file);
+#elif ZRLF == leb128d
+    leb128_decode(path, file);
 #else
 #error "ZRLF C preprocessor variable must be 'zlre' or 'zrld'"
 #endif


### PR DESCRIPTION
Testing this thoroughly ended up needing unit tests for LEB128 encoding and
decoding as a standalone unit since otherwise you need to work with
extremely long sequences of zeros. These could happen in principle, but
this lets us test our LEB128 functions without that. The leb128{e,d}
programs could be useful on their own, but it's hard to think of a
circumstance.